### PR TITLE
Delete AWS_PROFILE env var in lambda

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SST Tester
 
-Stack to recrate issues observed with permissions
+Stack to recreate issues observed with permissions
 
 ## Recreation Steps
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "@aws-cdk/core": "1.98.0",
+    "@aws-sdk/client-sts": "^3.15.0",
     "@serverless-stack/cli": "0.18.0",
     "@serverless-stack/resources": "0.18.0",
     "pino": "^6.11.3"

--- a/src/lambda.ts
+++ b/src/lambda.ts
@@ -2,24 +2,27 @@ import { APIGatewayProxyEventV2, APIGatewayProxyHandlerV2 } from "aws-lambda";
 
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb'
 import { DynamoDBDocument } from "@aws-sdk/lib-dynamodb"
+import { STSClient, GetCallerIdentityCommand } from "@aws-sdk/client-sts";
+
 import { buildLogger } from './common/logger'
 
-const client = new DynamoDBClient({
-  logger: console
-});
+delete(process.env.AWS_PROFILE)
+
+const client = new DynamoDBClient({ logger: console });
 const ddbDocClient = DynamoDBDocument.from(client);
+const stsClient = new STSClient({});
 
 export const handler: APIGatewayProxyHandlerV2 = async (
   event: APIGatewayProxyEventV2
 ) => {
-  const internalClient = new DynamoDBClient({
-    logger: console
-  });
+  const logger = buildLogger(event)
+  logger.info('Booted lambda')
+
+  const internalClient = new DynamoDBClient({ logger: console });
   const internalDdbDocClient = DynamoDBDocument.from(internalClient);
 
-  const logger = buildLogger(event)
-
-  logger.info('Booted lambda')
+  const callerIdentity = await stsClient.send(new GetCallerIdentityCommand({}))
+  logger.info({ callerIdentity }, 'Caller Identity')
 
   logger.info({
     client: client.config,
@@ -45,6 +48,17 @@ export const handler: APIGatewayProxyHandlerV2 = async (
   })
 
   logger.info('Performing put request')
+
+  await internalDdbDocClient.put({
+    TableName: process.env.NOTES_TABLE_NAME,
+    Item: {
+      userId: 'example-user-id',
+      noteId: 'example-note-id',
+      data: {
+        exists: false
+      }
+    }
+  })
 
   await ddbDocClient.put({
     TableName: process.env.NOTES_TABLE_NAME,

--- a/yarn.lock
+++ b/yarn.lock
@@ -927,7 +927,7 @@
     "@aws-sdk/util-utf8-node" "3.13.1"
     tslib "^2.0.0"
 
-"@aws-sdk/client-sts@3.15.0":
+"@aws-sdk/client-sts@3.15.0", "@aws-sdk/client-sts@^3.15.0":
   version "3.15.0"
   resolved "https://registry.yarnpkg.com/@aws-sdk/client-sts/-/client-sts-3.15.0.tgz#0a9cd801f626cb2f4338479671f5f12c7fd3f826"
   integrity sha512-allPrBwN1kIFhvjJKUFAnaHOVRwtOQoAjz58QP9x0Sg+Bxqpj399+iF3QxtbLLxWo9ituf9s+3FAOBHEC/ahiA==


### PR DESCRIPTION
This change ensures that the permissions for constructing the clients are inherited from the temporary credentials provided by SST, and not those of the AWS_PROFILE that was used to deploy the stack.

## Details

Operating system: Ubuntu 20.04.2 LTS
Node version: v12.16.3

## Recreation

Expected: 

the role to be used in the local execution of the lambda will be the role associated with the deployed lambda in order to have the same permissions when debugging.

Actual: 

If the `AWS_PROFILE` variable is set, the aws-sdk assumes the credentials for the profile on the local machine

![assumed-credentials-bug-recreation](https://user-images.githubusercontent.com/30017294/118230374-7b775400-b485-11eb-8fda-f8e140b55d33.gif)
